### PR TITLE
Fix authentication env variable in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ credentials when attempting to access the exposed endpoints via clients.
 It's also possible to provide a username/password combination via environment variables like so:
 
 ```bash
-docker run -e USER="Titus Bramble" -e PASSWORD="Shambles" infinispan/server
+docker run -e USER="Titus Bramble" -e PASS="Shambles" infinispan/server
 ```
 
 > We recommend utilising the auto-generated credentials or USER & PASS env variables for initial development only. Providing


### PR DESCRIPTION
As seen in `modules/runtime/added/bin/launch.sh` the authentication environment variables are named `USER` and `PASS`, but README.md states `PASSWORD`