### PR TITLE
RHDG 8.0.0.ER2

### DIFF
--- a/content_sets.yml
+++ b/content_sets.yml
@@ -1,0 +1,3 @@
+x86_64:
+  - rhel-8-for-x86_64-baseos-rpms
+  - rhel-8-for-x86_64-appstream-rpms

--- a/dg-override.yaml
+++ b/dg-override.yaml
@@ -1,11 +1,15 @@
 name: datagrid/datagrid-8
 version: 1.0
 description: Data Grid Server
+from: ubi8-minimal:8.0-released
 
-# artifacts:
-#   - name: server.zip
-#     description: TODO
-#     md5: TODO
+artifacts:
+  - name: server.zip
+    description: Red Hat Data Grid 8.0.0.ER2
+    md5: 0475c411a24b107bce9ca2b13e304831
+
+packages:
+  content_sets_file: content_sets.yml
 
 envs:
   - name: ISPN_HOME
@@ -15,17 +19,17 @@ labels:
   - name: name
     value: DG Server
   - name: version
-    value: 8.0.0-SNAPSHOT
+    value: 8.0.0.ER2
   - name: release
-    value: 8.0.0-SNAPSHOT
+    value: 8.0.0.ER2
   - name: com.redhat.component
-    value: jboss-datagrid-8-datagrid8-openshift-container
+    value: datagrid-8-rhel8-container
   - name: org.jboss.product
     value: datagrid
   - name: org.jboss.product.version
-    value: 8.0.0-SNAPSHOT
+    value: 8.0.0.ER2
   - name: org.jboss.product.datagrid.version
-    value: 8.0.0-SNAPSHOT
+    value: 8.0.0.ER2
   - name: "com.redhat.dev-mode"
     value: "DEBUG:true"
     description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."
@@ -47,7 +51,6 @@ osbs:
     container:
       compose:
           pulp_repos: true
-  # TODO update to correct name/branch
   repository:
-    name: containers/jboss-datagrid-8
-    branch: jb-datagrid-8.0-openshift-rhel-8
+    name: containers/datagrid-8
+    branch: datagrid-8-rhel8

--- a/modules/dependencies/install.sh
+++ b/modules/dependencies/install.sh
@@ -6,8 +6,5 @@ ADDED_DIR=$(dirname $0)/added
 # Override default java.config file so that tls is not disabled
 cp $ADDED_DIR/java.config /etc/crypto-policies/back-ends/java.config
 
-# Remove dnf and rpm files as package manager not required at runtime
-rm -rf /var/lib/rpm /var/lib/dnf
-
 # Create symlink between bsdtar and tar to enable `oc copy`
 ln -s $(command -v bsdtar) /usr/bin/tar


### PR DESCRIPTION
- Use the correct ubi8 image spec for building in Brew
- Use the correct value for 'com.redhat.component' label (Brew package)
- Use the Red Hat Data Grid 8.0.0.ER2 artifact
- Enable the use of content_sets.yml file
- Change version/release labels to a Brew-friendly format (no dashes allowed)
- Fix the dist-git repository and branch
- Add the content_sets.yml file, with the repos for rhel8
- Do not delete rpm/dnf repos info, needed for meta
There was a size optimization (8MB) deleting /var/lib/rpm and /var/lib/dnf inside the container.
However, this information is used by the all_rpm_packages plugin in Brew, in order to generate meta information for Lightblue (container grading, CVEs)
