### PR TITLE
Change labels to GA.1 to avoid image tag collision

### DIFF
--- a/dg-override.yaml
+++ b/dg-override.yaml
@@ -15,17 +15,17 @@ labels:
   - name: name
     value: DG Server
   - name: version
-    value: 8.0.0.GA
+    value: 8.0.0.GA.1
   - name: release
-    value: 8.0.0.GA
+    value: 8.0.0.GA.1
   - name: com.redhat.component
     value: datagrid-8-rhel8-container
   - name: org.jboss.product
     value: datagrid
   - name: org.jboss.product.version
-    value: 8.0.0.GA
+    value: 8.0.0.GA.1
   - name: org.jboss.product.datagrid.version
-    value: 8.0.0.GA
+    value: 8.0.0.GA.1
   - name: "com.redhat.dev-mode"
     value: "DEBUG:true"
     description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."


### PR DESCRIPTION
This is not a floating tag in Brew, so it didn't allow a new build for 8.0.0.GA.

Signed-off-by: Osni Oliveira <osni.oliveira@redhat.com>