### PR TITLE
Add version labels to OpenJ9 overrides file

### DIFF
--- a/openj9-override.yaml
+++ b/openj9-override.yaml
@@ -1,8 +1,16 @@
 name: datagrid/datagrid-8-openj9
 
 labels:
+  - name: version
+    value: 8.0.1.GA.1
+  - name: release
+    value: 8.0.1.GA.1
   - name: com.redhat.component
     value: datagrid-8-openj9-11-rhel8-container
+  - name: org.jboss.product.version
+    value: 8.0.1.GA.1
+  - name: org.jboss.product.datagrid.version
+    value: 8.0.1.GA.1
   - name: io.k8s.display-name
     value: Data Grid 8.0 OpenJ9
 


### PR DESCRIPTION
This way, the versions for x86_64 and s390x images might move independently