### PR TITLE
Bump version to 8.1.0.GA.5 for releasing multi-arch set

### DIFF
--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -1,7 +1,9 @@
 name: datagrid/datagrid-8
 version: 1.0
 description: Data Grid Server
-from: rh-osbs/ubi8-minimal:8-released
+
+from: registry.redhat.io/ubi8/ubi-minimal
+
 artifacts:
 - name: config-generator
   url: https://repository.jboss.org/org/infinispan/images/config-generator/2.0.2.Final/config-generator-2.0.2.Final-runner.jar

--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -22,17 +22,17 @@ labels:
   - name: name
     value: DG Server
   - name: version
-    value: 8.1.0.GA.4
+    value: 8.1.0.GA.5
   - name: release
-    value: 8.1.0.GA.4
+    value: 8.1.0.GA.5
   - name: com.redhat.component
     value: datagrid-8-rhel8-container
   - name: org.jboss.product
     value: datagrid
   - name: org.jboss.product.version
-    value: 8.1.0.GA.4
+    value: 8.1.0.GA.5
   - name: org.jboss.product.datagrid.version
-    value: 8.1.0.GA.4
+    value: 8.1.0.GA.5
   - name: "com.redhat.dev-mode"
     value: "DEBUG:true"
     description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."


### PR DESCRIPTION
No code changes, but we need a new build to be released together with the full set for multi-arch (x86_64 server, s390x server, operator multi-arch, bundle multi-arch). Just bumping the version and re-spinning.

Took the change to introduce:
JDG-4063 Use new specification for ubi8-minimal base image
See https://docs.engineering.redhat.com/pages/viewpage.action?pageId=87727140
https://issues.redhat.com/browse/JDG-4063
