### PR TITLE
Add openj9 rpm into content_sets.yml for s390x to avoid CVP content…

### DIFF
--- a/content_sets.yml
+++ b/content_sets.yml
@@ -4,3 +4,4 @@ x86_64:
 s390x:
   - rhel-8-for-s390x-baseos-rpms
   - rhel-8-for-s390x-appstream-rpms
+  - openj9-1-for-rhel-8-s390x-rpms


### PR DESCRIPTION
Add `openj9 rpm` into `content_sets.yml` for s390x to avoid CVP `content_set_check` failure
