### PR TITLE
Remove x86_64 from the OpenJ9 build

### DIFF
--- a/openj9-override.yaml
+++ b/openj9-override.yaml
@@ -23,7 +23,6 @@ osbs:
         signing_intent: release
       platforms:
         only:
-          - x86_64
           - s390x
   repository:
     name: containers/datagrid-8-openj9


### PR DESCRIPTION
Was building x86_64 with OpenJ9 to be able to test locally; in order to be released, this arch must not be present.
This fix things moving forward.