### PR TITLE
Add version labels to OpenJ9 overrides file

### DIFF
--- a/openj9-override.yaml
+++ b/openj9-override.yaml
@@ -1,8 +1,16 @@
 name: datagrid/datagrid-8-openj9
 
 labels:
+  - name: version
+    value: 8.1.0.GA.6
+  - name: release
+    value: 8.1.0.GA.6
   - name: com.redhat.component
     value: datagrid-8-openj9-11-rhel8-container
+  - name: org.jboss.product.version
+    value: 8.1.0.GA.6
+  - name: org.jboss.product.datagrid.version
+    value: 8.1.0.GA.6
   - name: io.k8s.display-name
     value: Data Grid 8.1 OpenJ9
 


### PR DESCRIPTION
Already did that in the `10.1.x` branch, necessary to keep x86_64 and s390x builds independent. In this case, we'll need to respin s390x because of a missing content_set, but no need to respin x86_64 too.