### PR TITLE
Bump version to 8.1.0.GA.7 for respin

### DIFF
--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -24,17 +24,17 @@ labels:
   - name: name
     value: DG Server
   - name: version
-    value: 8.1.0.GA.6
+    value: 8.1.0.GA.7
   - name: release
-    value: 8.1.0.GA.6
+    value: 8.1.0.GA.7
   - name: com.redhat.component
     value: datagrid-8-rhel8-container
   - name: org.jboss.product
     value: datagrid
   - name: org.jboss.product.version
-    value: 8.1.0.GA.6
+    value: 8.1.0.GA.7
   - name: org.jboss.product.datagrid.version
-    value: 8.1.0.GA.6
+    value: 8.1.0.GA.7
   - name: "com.redhat.dev-mode"
     value: "DEBUG:true"
     description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."


### PR DESCRIPTION
It seems that GA.6 has been already built. Going for 7