### PR TITLE
Bump version to avoid tag collision

### DIFF
--- a/openj9-override.yaml
+++ b/openj9-override.yaml
@@ -2,15 +2,15 @@ name: datagrid/datagrid-8-openj9
 
 labels:
   - name: version
-    value: 8.1.1.GA.3
+    value: 8.1.1.GA.4
   - name: release
-    value: 8.1.1.GA.3
+    value: 8.1.1.GA.4
   - name: com.redhat.component
     value: datagrid-8-openj9-11-rhel8-container
   - name: org.jboss.product.version
-    value: 8.1.1.GA.3
+    value: 8.1.1.GA.4
   - name: org.jboss.product.datagrid.version
-    value: 8.1.1.GA.3
+    value: 8.1.1.GA.4
   - name: io.k8s.display-name
     value: Data Grid 8.1 OpenJ9
 

--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -24,17 +24,17 @@ labels:
   - name: name
     value: DG Server
   - name: version
-    value: 8.1.1.GA.3
+    value: 8.1.1.GA.4
   - name: release
-    value: 8.1.1.GA.3
+    value: 8.1.1.GA.4
   - name: com.redhat.component
     value: datagrid-8-rhel8-container
   - name: org.jboss.product
     value: datagrid
   - name: org.jboss.product.version
-    value: 8.1.1.GA.3
+    value: 8.1.1.GA.4
   - name: org.jboss.product.datagrid.version
-    value: 8.1.1.GA.3
+    value: 8.1.1.GA.4
   - name: "com.redhat.dev-mode"
     value: "DEBUG:true"
     description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."


### PR DESCRIPTION
New builds for multi-arch, to have the full set of images in the first release