### PR TITLE
Create files needed for Data Grid 8.2 CD builds

### DIFF
--- a/content_sets.yml
+++ b/content_sets.yml
@@ -1,0 +1,11 @@
+x86_64:
+  - rhel-8-for-x86_64-baseos-rpms
+  - rhel-8-for-x86_64-appstream-rpms
+s390x:
+  - rhel-8-for-s390x-baseos-rpms
+  - rhel-8-for-s390x-appstream-rpms
+  - openj9-1-for-rhel-8-s390x-rpms
+ppc64le:
+  - rhel-8-for-ppc64le-baseos-rpms
+  - rhel-8-for-ppc64le-appstream-rpms
+  - openj9-1-for-rhel-8-ppc64le-rpms

--- a/openj9-override.yaml
+++ b/openj9-override.yaml
@@ -2,17 +2,17 @@ name: datagrid/datagrid-8-openj9
 
 labels:
   - name: version
-    value: 8.1.1.GA.4
+    value: 8.2.0.CD
   - name: release
-    value: 8.1.1.GA.4
+    value: 8.2.0.CD
   - name: com.redhat.component
     value: datagrid-8-openj9-11-rhel8-container
   - name: org.jboss.product.version
-    value: 8.1.1.GA.4
+    value: 8.2.0.CD
   - name: org.jboss.product.datagrid.version
-    value: 8.1.1.GA.4
+    value: 8.2.0.CD
   - name: io.k8s.display-name
-    value: Data Grid 8.1 OpenJ9
+    value: Data Grid 8.2 OpenJ9
 
 modules:
   install:

--- a/openj9-override.yaml
+++ b/openj9-override.yaml
@@ -1,0 +1,38 @@
+name: datagrid/datagrid-8-openj9
+
+labels:
+  - name: version
+    value: 8.1.1.GA.4
+  - name: release
+    value: 8.1.1.GA.4
+  - name: com.redhat.component
+    value: datagrid-8-openj9-11-rhel8-container
+  - name: org.jboss.product.version
+    value: 8.1.1.GA.4
+  - name: org.jboss.product.datagrid.version
+    value: 8.1.1.GA.4
+  - name: io.k8s.display-name
+    value: Data Grid 8.1 OpenJ9
+
+modules:
+  install:
+    # Override jdk module to use OpenJ9 specific one
+    - name: org.infinispan.dependencies.jdk
+      version: openj9
+
+osbs:
+  configuration:
+    container:
+      compose:
+        inherit: true
+        packages:
+          - java-11-openj9-devel
+        pulp_repos: true
+        signing_intent: release
+      platforms:
+        only:
+          - s390x
+          - ppc64le
+  repository:
+    name: containers/datagrid-8-openj9
+    branch: datagrid-8-openj9-rhel-8

--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -1,0 +1,110 @@
+name: datagrid/datagrid-8
+version: 1.1
+description: Data Grid Server
+
+from: registry.redhat.io/ubi8/ubi-minimal
+
+artifacts:
+- name: config-generator
+  url: https://repository.jboss.org/org/infinispan/images/config-generator/2.0.3.Final/config-generator-2.0.3.Final-runner.jar
+- name: server
+  description: Red Hat Data Grid 8.1.1.GA
+  md5: 6ff7cfd37c2085ecb3d09fc39eab877c
+packages:
+  manager: microdnf
+  content_sets_file: content_sets.yml
+ports:
+- value: 2157
+- value: 7800
+- value: 11221
+- value: 11222
+- value: 45700
+- value: 57600
+labels:
+  - name: name
+    value: DG Server
+  - name: version
+    value: 8.1.1.GA.4
+  - name: release
+    value: 8.1.1.GA.4
+  - name: com.redhat.component
+    value: datagrid-8-rhel8-container
+  - name: org.jboss.product
+    value: datagrid
+  - name: org.jboss.product.version
+    value: 8.1.1.GA.4
+  - name: org.jboss.product.datagrid.version
+    value: 8.1.1.GA.4
+  - name: "com.redhat.dev-mode"
+    value: "DEBUG:true"
+    description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."
+  - name: "com.redhat.dev-mode.port"
+    value: "DEBUG_PORT:8787"
+  - name: io.k8s.description
+    value: Provides a scalable in-memory distributed database designed for fast access to large volumes of data.
+  - name: io.k8s.display-name
+    value: Data Grid 8.1
+  - name: io.openshift.expose-services
+    value: 8080:http
+  - name: io.openshift.tags
+    value: datagrid,java,jboss,xpaas
+  - name: io.openshift.s2i.scripts-url
+    value: image:///usr/local/s2i
+  - name: maintainer
+    value: remerson@redhat.com
+envs:
+- name: ISPN_HOME
+  value: /opt/infinispan
+- name: CONFIG_PATH
+  description: The path to the .yaml file which contains all Infinispan related configuration.
+- name: IDENTITIES_PATH
+  description: The path to the .yaml file containing all identity information for configuring endpoints.
+- name: USER
+  description: When provided with the PASS variable, this value is used to generate a credential identitiy in a yaml file which is used to set IDENTITIES_PATH
+- name: PASS
+  description: When provided with the USER variable, this value is used to generate a credential identitiy in a yaml file which is used to set IDENTITIES_PATH
+- name: JAVA_OPTIONS
+  description: Allows java properties and options to be provided to the JVM when the server is launched.
+- name: JAVA_DIAGNOSTICS
+  description: Set this to get some diagnostics information to standard output when things are happening. **Disabled by default.**
+  example: true
+- name: JAVA_INIT_MEM_RATIO
+  description: This is used to calculate a default initial heap memory based the maximumal heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added.
+  value: 0
+- name: JAVA_MAX_MEM_RATIO
+  description: This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option is added.
+  value: 50
+- name: JAVA_GC_METASPACE_SIZE
+  description: The initial high-water mark for GC.
+  value: 32m
+- name: JAVA_GC_MAX_METASPACE_SIZE
+  description: The maximum metaspace size.
+  value: 96m
+modules:
+  repositories:
+  - path: modules
+  install:
+  - name: org.infinispan.dnf-workaround
+  - name: org.infinispan.dependencies.jdk
+    version: openjdk
+  - name: org.infinispan.dependencies
+    version: datagrid
+  - name: org.infinispan.distribution
+    version: jvm
+  - name: org.infinispan.runtime
+run:
+  cmd:
+  - ./bin/launch.sh
+  user: 185
+  workdir: /opt/infinispan
+osbs:
+  configuration:
+    container:
+      compose:
+        pulp_repos: true
+      platforms:
+        only:
+          - x86_64
+  repository:
+    name: containers/datagrid-8
+    branch: datagrid-8-rhel-8

--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -8,8 +8,8 @@ artifacts:
 - name: config-generator
   url: https://repository.jboss.org/org/infinispan/images/config-generator/2.1.2.Final/config-generator-2.1.2.Final-runner.jar
 - name: server
-  description: Red Hat Data Grid 8.1.1.GA
-  md5: 6ff7cfd37c2085ecb3d09fc39eab877c
+  description: ~
+  md5: ~
 packages:
   manager: microdnf
   content_sets_file: content_sets.yml

--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -1,5 +1,5 @@
 name: datagrid/datagrid-8
-version: 1.1
+version: 1.2
 description: Data Grid Server
 
 from: registry.redhat.io/ubi8/ubi-minimal
@@ -24,17 +24,17 @@ labels:
   - name: name
     value: DG Server
   - name: version
-    value: 8.1.1.GA.4
+    value: 8.2.0.CD
   - name: release
-    value: 8.1.1.GA.4
+    value: 8.2.0.CD
   - name: com.redhat.component
     value: datagrid-8-rhel8-container
   - name: org.jboss.product
     value: datagrid
   - name: org.jboss.product.version
-    value: 8.1.1.GA.4
+    value: 8.2.0.CD
   - name: org.jboss.product.datagrid.version
-    value: 8.1.1.GA.4
+    value: 8.2.0.CD
   - name: "com.redhat.dev-mode"
     value: "DEBUG:true"
     description: "Environment variable used to enable development mode (debugging). A value of true will enable development mode."
@@ -43,7 +43,7 @@ labels:
   - name: io.k8s.description
     value: Provides a scalable in-memory distributed database designed for fast access to large volumes of data.
   - name: io.k8s.display-name
-    value: Data Grid 8.1
+    value: Data Grid 8.2
   - name: io.openshift.expose-services
     value: 8080:http
   - name: io.openshift.tags

--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -6,7 +6,7 @@ from: registry.redhat.io/ubi8/ubi-minimal
 
 artifacts:
 - name: config-generator
-  url: https://repository.jboss.org/org/infinispan/images/config-generator/2.0.3.Final/config-generator-2.0.3.Final-runner.jar
+  url: https://repository.jboss.org/org/infinispan/images/config-generator/2.1.2.Final/config-generator-2.1.2.Final-runner.jar
 - name: server
   description: Red Hat Data Grid 8.1.1.GA
   md5: 6ff7cfd37c2085ecb3d09fc39eab877c


### PR DESCRIPTION
Obs: the artifact definition in `server-datagrid.yaml` is pointing to the 8.1.1 server, because this is intended to be replaced by an override file or parameter created on-the-fly by the CD Jenkins job. Ex. a file with the content below, or the command-line equivalent:
```
artifacts:
- name: server
  description: Red Hat Data Grid 8.2.0 CD
  url: http://rcm-guest.app.eng.bos.redhat.com/rcm-guest/staging/jboss-dg/JDG-8.2.x-CD/JDG-8.2.0.CD20210301/redhat-datagrid-8.2.0.CD20210301-server.zip
```
I don't know if it's worth creating/versioning this file, because it will be (ideally) changed daily, and just points to the latest CD build anyway.

Also, please let me know if you prefer I squash the commits before merging (left the original ones for review purposes).