### PR TITLE
Fix yaml schema issue after using "null" values for server artifact

### DIFF
--- a/server-datagrid.yaml
+++ b/server-datagrid.yaml
@@ -7,9 +7,6 @@ from: registry.redhat.io/ubi8/ubi-minimal
 artifacts:
 - name: config-generator
   url: https://repository.jboss.org/org/infinispan/images/config-generator/2.1.2.Final/config-generator-2.1.2.Final-runner.jar
-- name: server
-  description: ~
-  md5: ~
 packages:
   manager: microdnf
   content_sets_file: content_sets.yml


### PR DESCRIPTION
CEKit validates the schema before applying the overrides, and this started failing local builds.
The definition of the server artifact in the `server-datagrid.yaml` descriptor will be back after we reach CR1.