### PR TITLE
Add new script to start the GossipRouter

### DIFF
--- a/modules/org/infinispan/runtime/added/gossiprouter/bin/launch.sh
+++ b/modules/org/infinispan/runtime/added/gossiprouter/bin/launch.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# ===================================================================================
+# Entry point for the image which initiates the JGroups Gossip Router
+# ===================================================================================
+
+set -e
+
+JGROUPS_JAR=`find ${ISPN_HOME} -type f -name "jgroups-*.jar" | head -n 1`
+GOSSIP_CLASS="org.jgroups.stack.GossipRouter"
+
+if [ ! -f "${JGROUPS_JAR}" ]; then
+    # TODO create native binary of GossipRouter?
+    echo "Unable to start Gossip router"
+    echo "This image does not have JGroups jar file"
+    exit 1
+fi
+
+exec java -cp ${JGROUPS_JAR} ${GOSSIP_CLASS} $@

--- a/modules/org/infinispan/runtime/extract.sh
+++ b/modules/org/infinispan/runtime/extract.sh
@@ -3,7 +3,12 @@ set -e
 
 ADDED_DIR=$(dirname $0)/added
 SERVER_ROOT=/opt/infinispan
+GOSSIP_ROOT=/opt/gossiprouter
+
+mkdir -p ${GOSSIP_ROOT}/bin
 
 cp $ADDED_DIR/bin/* $SERVER_ROOT/bin
+cp ${ADDED_DIR}/gossiprouter/bin/* ${GOSSIP_ROOT}/bin
 chown -R 185 /opt
 chmod -R g+rwX $SERVER_ROOT
+chmod -R g+rwX ${GOSSIP_ROOT}


### PR DESCRIPTION
In k8s, we can use the same image to start the infinispan server (default entrypoint)
or the gossip router server

The gossip router server will be used to provide cross-site replication
between k8s clusters (a.k.a. Gossip Router Tunnel).

Tested locally and it will be consumed by https://github.com/infinispan/infinispan-operator/pull/1201
```
$ podman run --entrypoint /opt/gossiprouter/bin/launch.sh infinispan/server -port 8080

GossipRouter started in 95 ms listening on 0.0.0.0:8080
```