### PR TITLE
Utilise OpenJDK 17 runtime image #158

### DIFF
--- a/server-dev-jdk.yaml
+++ b/server-dev-jdk.yaml
@@ -1,7 +1,7 @@
 - name: infinispan/server
   version: latest
   description: Infinispan Server
-  from: registry.access.redhat.com/ubi8/openjdk-11-runtime
+  from: registry.access.redhat.com/ubi8/openjdk-17-runtime
   artifacts:
     - name: server
       path: artifacts/server

--- a/server-openjdk.yaml
+++ b/server-openjdk.yaml
@@ -1,7 +1,7 @@
 name: infinispan/server
 version: 13.0.2.Final-1
 description: Infinispan Server
-from: registry.access.redhat.com/ubi8/openjdk-11-runtime
+from: registry.access.redhat.com/ubi8/openjdk-17-runtime
 artifacts:
 - name: server
   url: https://downloads.jboss.org/infinispan/13.0.2.Final/infinispan-server-13.0.2.Final.zip


### PR DESCRIPTION
Can't be merged until the `openjdk-17-runtime` image is available on the unauthenticated registry.access.redhat.com repository.

[CLOUDDST-10475](https://issues.redhat.com/browse/CLOUDDST-10475).