### PR TITLE
Upgrade images to ubi9 #175

### DIFF
--- a/cli-dev.yaml
+++ b/cli-dev.yaml
@@ -1,7 +1,7 @@
 - name: infinispan/cli
   version: latest
   description: Infinispan Quarkus Server
-  from: registry.access.redhat.com/ubi8/ubi-minimal
+  from: registry.access.redhat.com/ubi9/ubi-minimal
   artifacts:
   - name: cli
     path: artifacts/cli

--- a/cli.yaml
+++ b/cli.yaml
@@ -15,7 +15,7 @@
 - name: infinispan/cli
   version: 14.0.0.Dev02-1
   description: Infinispan Quarkus Server
-  from: registry.access.redhat.com/ubi8/ubi-minimal
+  from: registry.access.redhat.com/ubi9/ubi-minimal
   artifacts:
   - name: cli
     image: native-builder

--- a/server-dev-native.yaml
+++ b/server-dev-native.yaml
@@ -1,7 +1,7 @@
 - name: infinispan/server-native
   version: latest
   description: Infinispan Quarkus Server
-  from: registry.access.redhat.com/ubi8/ubi-minimal
+  from: registry.access.redhat.com/ubi9/ubi-minimal
   artifacts:
     - name: cli
       path: artifacts/cli

--- a/server-native.yaml
+++ b/server-native.yaml
@@ -16,7 +16,7 @@
 - name: infinispan/server-native
   version: 14.0.0.Dev02-1
   description: Infinispan Quarkus Server
-  from: registry.access.redhat.com/ubi8/ubi-minimal
+  from: registry.access.redhat.com/ubi9/ubi-minimal
   artifacts:
   - name: cli
     image: native-builder


### PR DESCRIPTION
The ubi9 JDK image`registry.access.redhat.com/ubi9/openjdk-17-runtime` is not yet available.
