### PR TITLE
Updated java options manage. Fixes #229

### DIFF
--- a/modules/org/infinispan/distribution/jvm/added/bin/java-opts.sh
+++ b/modules/org/infinispan/distribution/jvm/added/bin/java-opts.sh
@@ -1,13 +1,12 @@
 #!/bin/sh
 # ===================================================================================
-# Generic startup script for running arbitrary Java applications with
-# being optimized for running in containers
-#
-# Modified version of https://github.com/fabric8io-images/run-java-sh/blob/master/fish-pepper/run-java-sh/fp-files/run-java.sh
-# ===================================================================================
-
+## Generic startup script for running arbitrary Java applications with
+## being optimized for running in containers
+##
+## get_java_opts imported version from https://github.com/jboss-container-images/openjdk/blob/ubi9/modules/run/artifacts/opt/jboss/container/java/run/run-java.sh
+## ===================================================================================
 if [ -n "${DEBUG:-}" ]; then
-  set -x
+ set -x
 fi
 
 # ksh is different for defining local vars
@@ -15,122 +14,46 @@ if [ -n "${KSH_VERSION:-}" ]; then
   alias local=typeset
 fi
 
-# Generic formula evaluation based on awk
-calc() {
-  local formula="$1"
-  shift
-  echo "$@" | awk '
-    function ceil(x) {
-      return x % 1 ? int(x) + 1 : x
-    }
-    function log2(x) {
-      return log(x)/log(2)
-    }
-    function max2(x, y) {
-      return x > y ? x : y
-    }
-    function round(x) {
-      return int(x + 0.5)
-    }
-    {print '"int(${formula})"'}
-  '
-}
+export JBOSS_CONTAINER_UTIL_LOGGING_MODULE="${JBOSS_CONTAINER_UTIL_LOGGING_MODULE-/opt/jboss/container/util/logging}"
+export JBOSS_CONTAINER_JAVA_RUN_MODULE="${JBOSS_CONTAINER_JAVA_RUN_MODULE-/opt/jboss/container/java/run}"
 
-max_memory() {
-  # High number which is the max limit until which memory is supposed to be
-  # unbounded.
-  local mem_file="/sys/fs/cgroup/memory.max"
-  if [ ! -r "${mem_file}" ]; then
-    mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
-  fi
-  if [ -r "${mem_file}" ]; then
-    local max_mem_cgroup="$(cat ${mem_file})"
-    local max_mem_meminfo_kb="$(cat /proc/meminfo | awk '/MemTotal/ {print $2}')"
-    local max_mem_meminfo="$(expr $max_mem_meminfo_kb \* 1024)"
-    if [ ${max_mem_cgroup:-0} != -1 ] && [ ${max_mem_cgroup:-0} -lt ${max_mem_meminfo:-0} ]
-    then
-      echo "${max_mem_cgroup}"
-    fi
-  fi
-}
+# Default the application dir to the S2I deployment dir
+if [ -z "$JAVA_APP_DIR" ]
+  then JAVA_APP_DIR=/deployments
+fi
 
-init_limit_env_vars() {
-  # Read in container limits and export the as environment variables
-  local mem_limit="$(max_memory)"
-  if [ -n "${mem_limit}" ]; then
-    export CONTAINER_MAX_MEMORY="${mem_limit}"
-  fi
-}
+source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
 
-# ==========================================================================
-# Check for memory options and set max heap size if needed
-calc_max_memory() {
-  # Check whether -Xmx is already given in JAVA_OPTIONS
-  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xmx"; then
-    return
+# ==========================================================
+# Generic run script for running arbitrary Java applications
+#
+# This has forked (and diverged) from:
+# at https://github.com/fabric8io/run-java-sh
+#
+# ==========================================================
+
+# Combine all java options
+get_java_options() {
+  local jvm_opts
+  local debug_opts
+  local proxy_opts
+  local opts
+  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options" ]; then
+    jvm_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/java-default-options)
+  fi
+  if [ -f "${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options" ]; then
+    debug_opts=$(${JBOSS_CONTAINER_JAVA_JVM_MODULE}/debug-options)
+  fi
+  if [ -f "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options" ]; then
+    source "${JBOSS_CONTAINER_JAVA_PROXY_MODULE}/proxy-options"
+    proxy_opts="$(proxy_options)"
   fi
 
-  if [ -z "${CONTAINER_MAX_MEMORY:-}" ]; then
-    return
-  fi
-
-  # Check for the 'real memory size' and calculate Xmx from the ratio
-  if [ -n "${JAVA_MAX_MEM_RATIO:-}" ]; then
-    if [ "${JAVA_MAX_MEM_RATIO}" -eq 0 ]; then
-      # Explicitely switched off
-      return
-    fi
-    calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_MAX_MEM_RATIO}" "mx"
-  fi
-  # When JAVA_MAX_MEM_RATIO not set and JVM >= 10 no max_memory
-}
-
-# Check for memory options and set initial heap size if requested
-calc_init_memory() {
-  # Check whether -Xms is already given in JAVA_OPTIONS.
-  if echo "${JAVA_OPTIONS:-}" | grep -q -- "-Xms"; then
-    return
-  fi
-
-  # Check if value set
-  if [ -z "${JAVA_INIT_MEM_RATIO:-}" ] || [ -z "${CONTAINER_MAX_MEMORY:-}" ] || [ "${JAVA_INIT_MEM_RATIO}" -eq 0 ]; then
-    return
-  fi
-
-  # Calculate Xms from the ratio given
-  calc_mem_opt "${CONTAINER_MAX_MEMORY}" "${JAVA_INIT_MEM_RATIO}" "ms"
-}
-
-calc_mem_opt() {
-  local max_mem="$1"
-  local fraction="$2"
-  local mem_opt="$3"
-
-  local val=$(calc 'round($1*$2/100/1048576)' "${max_mem}" "${fraction}")
-  echo "-X${mem_opt}${val}m"
-}
-
-# Switch on diagnostics except when switched off
-diagnostics_options() {
-  if [ -n "${JAVA_DIAGNOSTICS:-}" ]; then
-    echo "-XX:NativeMemoryTracking=summary -Xlog:gc*:stdout:time -XX:+UnlockDiagnosticVMOptions"
-  fi
-}
-
-gc_options() {
-  local gc_options="-XX:+ExitOnOutOfMemoryError"
-  if [ -n "${JAVA_GC_METASPACE_SIZE:-}" ] || [ "${JAVA_GC_METASPACE_SIZE//[!0-9]/}" -gt 0 ]; then
-    gc_options="${gc_options} -XX:MetaspaceSize=${JAVA_GC_METASPACE_SIZE}"
-  fi
-
-  if [ -n "${JAVA_GC_MAX_METASPACE_SIZE:-}" ] || [ "${JAVA_GC_MAX_METASPACE_SIZE//[!0-9]/}" -gt 0 ]; then
-    gc_options="${gc_options} -XX:MaxMetaspaceSize=${JAVA_GC_MAX_METASPACE_SIZE}"
-  fi
-  echo ${gc_options}
+  opts=${JAVA_OPTS-${debug_opts} ${proxy_opts} ${jvm_opts} ${JAVA_OPTS_APPEND}}
+  # Normalize spaces with awk (i.e. trim and eliminate double spaces)
+  echo "${opts}" | awk '$1=$1'
 }
 
 java_opts() {
-  init_limit_env_vars
-  # Echo options, trimming trailing and multiple spaces
-  echo "${JAVA_OPTIONS:-} $(calc_init_memory) $(calc_max_memory) $(diagnostics_options) $(gc_options)" | awk '$1=$1'
+   get_java_options
 }

--- a/modules/org/infinispan/distribution/jvm/added/bin/java-opts.sh
+++ b/modules/org/infinispan/distribution/jvm/added/bin/java-opts.sh
@@ -24,14 +24,6 @@ fi
 
 source "$JBOSS_CONTAINER_UTIL_LOGGING_MODULE/logging.sh"
 
-# ==========================================================
-# Generic run script for running arbitrary Java applications
-#
-# This has forked (and diverged) from:
-# at https://github.com/fabric8io/run-java-sh
-#
-# ==========================================================
-
 # Combine all java options
 get_java_options() {
   local jvm_opts

--- a/modules/org/infinispan/distribution/jvm/added/bin/server.conf
+++ b/modules/org/infinispan/distribution/jvm/added/bin/server.conf
@@ -1,6 +1,10 @@
 # Set jvm args reflecting container limits and configured env vars
 . $ISPN_HOME/bin/java-opts.sh
-JAVA_OPTS="$(java_opts)"
+
+set +eo pipefail
+
+# Append JAVA_OPTIONS and the end so user can override defaults
+JAVA_OPTS="$(java_opts) $JAVA_OPTIONS"
 
 # Add java options required by Infinispan
 export JAVA_OPTS="$JAVA_OPTS -Djava.net.preferIPv4Stack=true -Djava.awt.headless=true"


### PR DESCRIPTION
Updates java-opts.sh with the latest from run-java.sh
unfortunately run-java.sh funcs cannot be imported without execute the script, so copy is needed


